### PR TITLE
Logging the error when something goes wrong while opening the tunnel

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,14 @@ module.exports.startTunnel = function(options) {
             callback();
         },
         function (callback) {
-            tunnel.start(function() {
+            tunnel.start(function(error) {
+              if (error) {
+                console.log(error);
+                process.exit(1);
+              }
+              else {
                 callback();
+              }
             });
         }
     );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-browserstack",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Start and stop SSH tunnels to BrowserStack in your Gulp pipeline.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
My tests were not running and I had no output message telling me what was going wrong. While looking at browserstack tunnel wrapper code I saw it sends and error object if something go wrong. I just added a console log of this error object and I'm also failing the task in case it's defined.

What do you think?
