### PR TITLE
Fix handling of multiple input files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+node_modules/
+.idea/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,12 +8,12 @@ gulp.task('webdriver-standalone', protractor.webdriver_standalone);
 
 gulp.task('test', ['webdriver-update'], function() {
     return gulp
-        .src('test.js')
+        .src(['test/test.js', 'test/test-two.js'])
         .pipe(tunnel.startTunnel({
             key: process.env.BROWSERSTACK_KEY
         }))
         .pipe(protractor.protractor({
-            configFile: __dirname + '/protractor.config.js'
+            configFile: __dirname + '/test/protractor.config.js'
         }))
         .pipe(tunnel.stopTunnel());
 });

--- a/test/protractor.config.js
+++ b/test/protractor.config.js
@@ -2,7 +2,6 @@ exports.config = {
     baseUrl: 'https://google.com',
     rootElement: 'body',
     framework: 'jasmine2',
-    specs: ['test.js'],
     maxSessions: 1,
     jasmineNodeOpts: {
         defaultTimeoutInterval: 360000

--- a/test/test-two.js
+++ b/test/test-two.js
@@ -1,0 +1,8 @@
+describe('gulp-browserstack', function() {
+    it('should work with multiple spec files', function() {
+        browser.get(browser.baseUrl);
+        var input = element(by.css('input[name="q"]'));
+
+        expect(input.isPresent()).toBe(true);
+    });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@ describe('gulp-browserstack', function() {
     it('should establish a tunnel', function() {
         browser.get(browser.baseUrl);
         var input = element(by.css('input[name="q"]'));
-        
-        expect(input).not.toBe(undefined);
+
+        expect(input.isPresent()).toBe(true);
     });
 });


### PR DESCRIPTION
Running a test with multiple spec files would cause a new BrowserStack tunnel to be started for each spec file. For projects with a large number of spec files this causes an overflow error in Gulp.

It seems that the construction with the `tunnelStarted` flag was not working correctly: the flag is always `false` when checked. The startTunnel() method now checks the `tunnel` object directly, solving the issue and removing the need for a separate `tunnelStarted` flag.

I added a second test file to the project to make sure everything works as it should.
